### PR TITLE
Use rel=modulepreload instead of rel=preload and enable early hints

### DIFF
--- a/examples/blog/bin/serve
+++ b/examples/blog/bin/serve
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Starts the Rails server in production mode.
-RAILS_SERVE_STATIC_FILES=true RAILS_ENV=production bin/rails s
+RAILS_SERVE_STATIC_FILES=true RAILS_ENV=production bin/rails s "$@"

--- a/examples/blog/config/puma.rb
+++ b/examples/blog/config/puma.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+early_hints true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/lib/tasks/vite/clobber.rake
+++ b/lib/tasks/vite/clobber.rake
@@ -16,5 +16,7 @@ unless skip_vite_clobber
     Rake::Task['assets:clobber'].enhance do
       Rake::Task['vite:clobber'].invoke
     end
+  else
+    Rake::Task.define_task('assets:clobber' => 'vite:clobber')
   end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -50,8 +50,8 @@ class HelperTest < ActionView::TestCase
   def test_vite_javascript_tag
     assert_equal [
       %(<script src="/vite-production/assets/application.d9514acc.js" crossorigin="anonymous" type="module"></script>),
-      %(<link rel="preload" href="/vite-production/assets/vendor.880705da.js" as="script" type="text/javascript" crossorigin="anonymous">),
-      %(<link rel="preload" href="/vite-production/assets/example_import.8e1fddc0.js" as="script" type="text/javascript" crossorigin="anonymous">),
+      %(<link rel="modulepreload" href="/vite-production/assets/vendor.880705da.js" as="script" crossorigin="anonymous">),
+      %(<link rel="modulepreload" href="/vite-production/assets/example_import.8e1fddc0.js" as="script" crossorigin="anonymous">),
       link(href: '/vite-production/assets/application.f510c1e9.css'),
     ].join, vite_javascript_tag('application')
 


### PR DESCRIPTION
### Description 📖

This pull request switches from `rel=preload` to `rel=modulepreload`.

While Firefox still doesn't support `modulepreload`, support is over 70%, and the advantage of parsing ahead of time is too big to pass on.

### Compatibility

Since Rails doesn't yet have a helper for `modulepreload`, added a new helper, and as a result preload links can now be used in `5.1`.